### PR TITLE
Bug fixes for missing Status Property and Object

### DIFF
--- a/src/Resource/Database/PropertyConfiguration/StatusPropertyConfiguration.php
+++ b/src/Resource/Database/PropertyConfiguration/StatusPropertyConfiguration.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\Database\PropertyConfiguration;
+
+use Brd6\NotionSdkPhp\Resource\Property\AbstractProperty;
+
+class StatusPropertyConfiguration extends AbstractProperty
+{
+    public static function fromRawData(array $rawData): self
+    {
+        return new self();
+    }
+}

--- a/src/Resource/Database/PropertyObject/StatusPropertyObject.php
+++ b/src/Resource/Database/PropertyObject/StatusPropertyObject.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\Database\PropertyObject;
+
+use Brd6\NotionSdkPhp\Resource\Database\PropertyConfiguration\StatusPropertyConfiguration;
+use Brd6\NotionSdkPhp\Resource\Database\PropertyConfiguration\TitlePropertyConfiguration;
+
+class StatusPropertyObject extends AbstractPropertyObject
+{
+    protected ?StatusPropertyConfiguration $title = null;
+
+    public function __construct()
+    {
+        $this->status = new StatusPropertyConfiguration();
+    }
+
+    protected function initialize(): void
+    {
+        $this->status = isset($this->getRawData()['status']) ?
+            StatusPropertyConfiguration::fromRawData((array) $this->getRawData()['status']) :
+            null;
+    }
+
+    public function getStatus(): ?StatusPropertyConfiguration
+    {
+        return $this->status;
+    }
+
+    public function setStatus(?StatusPropertyConfiguration $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+}

--- a/src/Resource/Page/PropertyValue/StatusPropertyValue.php
+++ b/src/Resource/Page/PropertyValue/StatusPropertyValue.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\Page\PropertyValue;
+
+use Brd6\NotionSdkPhp\Exception\InvalidRichTextException;
+use Brd6\NotionSdkPhp\Exception\UnsupportedRichTextTypeException;
+use Brd6\NotionSdkPhp\Resource\RichText\AbstractRichText;
+
+use function array_map;
+
+class StatusPropertyValue extends AbstractPropertyValue
+{
+    /**
+     * @var array|AbstractRichText[]
+     */
+    protected array $status = [];
+
+    /**
+     * @throws InvalidRichTextException
+     * @throws UnsupportedRichTextTypeException
+     */
+    protected function initialize(): void
+    {
+        $this->status = ($this->getRawData()[$this->getType()] ?? '');
+    }
+
+    /**
+     * @return array|AbstractRichText[]
+     */
+    public function getStatus(): array
+    {
+        return $this->status;
+    }
+
+    /**
+     * @param array|AbstractRichText[] $status
+     */
+    public function setTtatus(array $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
Bug fixes for missing Status field/column support

## Description
I added StatusProperty for Page and StatusProperty supported for Database

## Motivation and context
Fixed the error

Brd6\NotionSdkPhp\Exception\UnsupportedPropertyObjectException : The given property object "status" is unsupported.

at /var/www/vendor/brd6/notion-sdk-php/src/Resource/Database/PropertyObject/AbstractPropertyObject.php:70
66| $typeFormatted = StringHelper::snakeCaseToCamelCase($type);
67| $class = "Brd6\NotionSdkPhp\Resource\Database\PropertyObject\{$typeFormatted}PropertyObject";
68|
69| if (!class_exists($class)) {

70| throw new UnsupportedPropertyObjectException($type);
71| }
72|
73| return $class;
74| }

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested with PHP 7.4
DB and Page can support Status Property and Object after the fix 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
